### PR TITLE
Opt-in to removal of deprecated helper classes and purging of unused classes

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,8 @@
 module.exports = {
+    future: {
+        removeDeprecatedGapUtilities: true,
+        purgeLayersByDefault: true,
+    },
     purge: [],
     theme: {
         extend: {


### PR DESCRIPTION
Feel free to ignore this if you don't care to future proof right now, doesn't seem to break anything though.

removeDeprecatedGapUtilities removes soon to be deprocated grid gap helper classes
purgeLayersByDefault purges all unused helpers from production builds